### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Fullscreen Background - jQuery plugin
+# Fullscreen Background - jQuery plugin
 
 
 Fullscreen background is a small jQuery plugin that allows you to create fullscreen background.
@@ -9,7 +9,7 @@ Fullscreen background is a small jQuery plugin that allows you to create fullscr
 
 ---
 
-##How to use:
+## How to use:
 
 1. Include jQuery on your webpage
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
